### PR TITLE
Add an Pull Request template #39

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+<!--
+Thank you for sending the PR! We appreciate you spending the time to work on these changes.
+
+Help us understand your motivation by explaining why you decided to make this change.
+
+You can learn more about contributing here: https://github.com/Agrover112/fliscopt/blob/master/CONTRIBUTING.md
+
+Happy contributing!
+
+-->
+
+## What does this PR do?
+
+(Provide a description of what this PR does.)
+
+## Test Plan
+
+(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)
+
+## Related PRs and Issues
+
+(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)
+
+### Have you read the [Contributing Guidelines on issues](https://github.com/Agrover112/fliscopt/blob/master/CONTRIBUTING.md)?
+
+(Write your answer here.)


### PR DESCRIPTION
Closes #39 

Renamed `PULL_REQUEST.md` to to `pull_request_template.md` following these instructions https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository

This has been tested as shown in the screenshot. 
![image](https://user-images.githubusercontent.com/20643587/138001321-c02fee80-d634-425f-a1e7-dab115b235b8.png)
